### PR TITLE
Fix wrong timestamp in trackpoints

### DIFF
--- a/src/exporters/gpx_exporter.py
+++ b/src/exporters/gpx_exporter.py
@@ -60,7 +60,7 @@ class GpxExporter(BaseExporter):
                 fp.write(
                     f'{ind}{ind}{ind}<trkpt lat="{point.latitude}" lon="{point.longitude}">'
                     f"<ele>{point.altitude}</ele>"
-                    f"<time>{time}</time>"
+                    f"<time>{point.time.isoformat()}</time>"
                     f"<extensions>"
                     f"{ext_hr}{ext_cadence}"
                     f"</extensions>"


### PR DESCRIPTION
Uses the correct timestamp of the trackpoint in the GPX export. 

Previously, the summary timestamp was used for each point and made the exported GPX useless.