### PR TITLE
Fix run instructions to avoid manual venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uv sync
 The script authenticates the user with the API then exports all workouts to the output directory using the specified file format.
 
 ```bash
-python3 main.py [-h] [-e ENDPOINT] [-t TOKEN] [-f {gpx,geojson,gpkg,parquet,shp,csv,json,xlsx,sql,sqlite3,xml,html}] [-o OUTPUT_DIRECTORY]
+uv run python3 main.py [-h] [-e ENDPOINT] [-t TOKEN] [-f {gpx,geojson,gpkg,parquet,shp,csv,json,xlsx,sql,sqlite3,xml,html}] [-o OUTPUT_DIRECTORY]
 ```
 
 ## Acknowledgements 


### PR DESCRIPTION
First of all, thank you for your awesome job!

Given that we use `uv sync` and it creates the venv but doesn't auto activate it, it's less error prone to prefix with uv run so the venv is used without manual activation. The way it's documented, it will run with current python interpreter in path which will probably won't match the newly created venv