### PR TITLE
Support exporting workouts without GPS data + richer metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /db_parameters.py
 /PostgreSQL.py
 /.ipynb_checkpoints/PostgreSQL-checkpoint.py
+.idea
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,23 +1,45 @@
 # Mi Fit and Zepp workout exporter
 
-This repository contains an example Python implementation for the [article](https://rolandszabo.com/reverse-engineering/mi-fit/export-mi-fit-and-zepp-workout-data).
+This repository contains an example Python implementation for the [article](https://rolandszabo.com/reverse-engineering/mi-fit/export-mi-fit-and-zepp-workout-data). It exports all your workouts from Mi Fit/Zepp, including those without GPS data, to various file formats.
 
 ## Environment setup
+
 ```bash
 uv sync
 ```
 
 ## Usage
+
 The script authenticates the user with the API then exports all workouts to the output directory using the specified file format.
 
+By default, only workouts with GPS data are exported. Use the `--include-no-gps` flag to include all workouts, even those without location data (e.g., indoor activities). Workouts without GPS will include available metadata in the exported files.
+
 ```bash
-uv run python3 main.py [-h] [-e ENDPOINT] [-t TOKEN] [-f {gpx,geojson,gpkg,parquet,shp,csv,json,xlsx,sql,sqlite3,xml,html}] [-o OUTPUT_DIRECTORY] [--start-date START_DATE] [--end-date END_DATE]
+uv run python3 main.py [-h] [-e ENDPOINT] [-t TOKEN] [-f {gpx,geojson,gpkg,parquet,shp,csv,json,xlsx,sql,sqlite3,xml,html}] [-o OUTPUT_DIRECTORY] [--start-date START_DATE] [--end-date END_DATE] [--include-no-gps]
 ```
 
-## Acknowledgements 
+### Options
+
+- `-e, --endpoint`: API endpoint (default: https://api-mifit.huami.com)
+- `-t, --token`: Application token (auto-obtained if not provided)
+- `-f, --file-format`: Output format (default: gpx)
+- `-o, --output-directory`: Output directory (default: ./workouts)
+- `--start-date`: Start date in YYYY-MM-DD (optional)
+- `--end-date`: End date in YYYY-MM-DD (optional)
+- `--include-no-gps`: Include workouts without GPS data
+
+### Exported Data
+
+- **Workouts with GPS**: Full track data with timestamps, coordinates, heart rate, cadence, etc.
+- **Workouts without GPS** (with `--include-no-gps`): Metadata including distance, calories, duration, steps, altitude changes, heart rate zones (if available), and activity details.
+- Supported formats: GPX (tracks), GeoJSON/GPKG/Shapefile (geospatial), CSV/JSON/XLSX (tabular), etc.
+
+## Acknowledgements
+
 The latitude/longitude parsing is based on Miroslav Bendík's [MiFitDataExport](https://github.com/mireq/MiFitDataExport) project.
 
 ## How to get the token manually
+
 If the authentication does not work out of the box, you can also provide the token manually:
 
 1. Open the [GDPR page](https://user.huami.com/privacy2/index.html?loginPlatform=web&platform_app=com.xiaomi.hm.health)

--- a/main.py
+++ b/main.py
@@ -33,7 +33,8 @@ def parse_date_to_timestamp(date_str, is_end=False):
         return math.inf if is_end else -math.inf
 
     try:
-        dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        dt = datetime.strptime(
+            date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
         if is_end:
             dt = dt.replace(hour=23, minute=59, second=59, microsecond=999999)
@@ -84,6 +85,11 @@ if __name__ == "__main__":
         type=str,
         help="End date in YYYY-MM-DD format (optional)"
     )
+    ap.add_argument(
+        "--include-no-gps",
+        action="store_true",
+        help="Include workouts that have no GPS data"
+    )
 
     args = vars(ap.parse_args())
 
@@ -102,5 +108,6 @@ if __name__ == "__main__":
         start_ts = parse_date_to_timestamp(args["start_date"], is_end=False)
         end_ts = parse_date_to_timestamp(args["end_date"], is_end=True)
 
-        scraper = Scraper(api, exporter, args["output_directory"], args["file_format"], start_ts, end_ts)
+        scraper = Scraper(api, exporter, args["output_directory"],
+                          args["file_format"], start_ts, end_ts, args["include_no_gps"])
         scraper.run()

--- a/src/api.py
+++ b/src/api.py
@@ -146,6 +146,9 @@ class WorkoutDetail(BaseModel):
     code: int
     message: str
     data: WorkoutDetailData
+    activity: Optional[Dict[str, Any]] = None
+    summary: Optional[Dict[str, Any]] = None
+    heart_rate_zones: Optional[Dict[str, Any]] = None
 
 
 class Api:
@@ -171,6 +174,7 @@ class Api:
                 "source": workout.source,
             },
         )
+        # Parse the response
         model = WorkoutDetail(**response)
         return model
 

--- a/src/exporters/base_exporter.py
+++ b/src/exporters/base_exporter.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from src.api import WorkoutDetailData, WorkoutSummary
+from src.api import WorkoutDetail, WorkoutDetailData, WorkoutSummary
 
 NO_VALUE = -2000000
 FIX_BIP_GAPS = False
@@ -35,7 +35,8 @@ RawTrackData = namedtuple(
     ],
 )
 Position = namedtuple("Position", ["lat", "lon", "alt"])
-TrackPoint = namedtuple("TrackPoint", ["time", "position", "hr", "stride", "cadence"])
+TrackPoint = namedtuple(
+    "TrackPoint", ["time", "position", "hr", "stride", "cadence"])
 
 
 class Interpolate(object):
@@ -43,7 +44,8 @@ class Interpolate(object):
         intervals = zip(x_list, x_list[1:], y_list, y_list[1:])
         self.x_list = x_list
         self.y_list = y_list
-        self.slopes = [(y2 - y1) // ((x2 - x1) or 1) for x1, x2, y1, y2 in intervals]
+        self.slopes = [(y2 - y1) // ((x2 - x1) or 1)
+                       for x1, x2, y1, y2 in intervals]
 
     def __getitem__(self, x):
         i = bisect_left(self.x_list, x) - 1
@@ -181,7 +183,8 @@ def track_points(track_data):
     ):
         yield TrackPoint(
             time=time,
-            position=Position(lat=lat / 100000000, lon=lon / 100000000, alt=alt / 100),
+            position=Position(lat=lat / 100000000, lon=lon /
+                              100000000, alt=alt / 100),
             hr=hr,
             stride=stride,
             cadence=cadence,
@@ -217,7 +220,8 @@ def interpolate_data(track_data):
             hr_times = change_times(hr_times, time_change, max_time)
             step_times = change_times(step_times, time_change, max_time)
             time_to_trim += time_change
-            times = list(sorted(set(track_times).union(hr_times).union(step_times)))
+            times = list(
+                sorted(set(track_times).union(hr_times).union(step_times)))
 
     return track_data._replace(
         times=times,
@@ -266,5 +270,6 @@ class BaseExporter(abc.ABC):
         output_file_path: Path,
         summary: WorkoutSummary,
         points: List[ExportablePoint],
+        detail: WorkoutDetail,
     ):
         raise NotImplementedError()

--- a/src/exporters/geopandas_exporter.py
+++ b/src/exporters/geopandas_exporter.py
@@ -35,25 +35,26 @@ class GeoPandasExporter(BaseExporter):
         summary: WorkoutSummary,
         points: List[ExportablePoint],
     ):
-        track_date = datetime.utcfromtimestamp(int(summary.trackid)).isoformat()
+        track_date = datetime.utcfromtimestamp(
+            int(summary.trackid)).isoformat()
 
-        data = [
-            {
-                "track_date": track_date,
-                "timestamp": point.time.isoformat(),
-                "latitude": point.latitude,
-                "longitude": point.longitude,
-                "altitude": point.altitude,
-                "heart_rate": point.heart_rate,
-                "cadence": point.cadence,
-                "geometry": Point(point.latitude, point.longitude),
-            }
-            for point in points
-        ]
-
-        gdf = gpd.GeoDataFrame(data, geometry="geometry")
-        gdf = gdf[
-            [
+        if points:
+            data = [
+                {
+                    "track_date": track_date,
+                    "timestamp": point.time.isoformat(),
+                    "latitude": point.latitude,
+                    "longitude": point.longitude,
+                    "altitude": point.altitude,
+                    "heart_rate": point.heart_rate,
+                    "cadence": point.cadence,
+                    # Note: Point(lon, lat)
+                    "geometry": Point(point.longitude, point.latitude),
+                }
+                for point in points
+            ]
+            gdf = gpd.GeoDataFrame(data, geometry="geometry")
+            columns = [
                 "track_date",
                 "timestamp",
                 "latitude",
@@ -63,39 +64,99 @@ class GeoPandasExporter(BaseExporter):
                 "cadence",
                 "geometry",
             ]
-        ]
-        gdf.geometry = gdf.geometry.set_crs(epsg=4326)
-        gdf.geometry = gdf.geometry.to_crs(epsg=4326)
+            gdf = gdf[columns]
+            gdf.geometry = gdf.geometry.set_crs(epsg=4326)
+            gdf.geometry = gdf.geometry.to_crs(epsg=4326)
+        else:
+            # For workouts without GPS, use regular DataFrame with metadata
+            import pandas as pd
+            data = [{
+                "track_date": track_date,
+                "timestamp": track_date,
+                "latitude": None,
+                "longitude": None,
+                "altitude": None,
+                "heart_rate": summary.avg_heart_rate if summary.avg_heart_rate else None,
+                "cadence": None,
+                "distance_km": summary.dis,
+                "calories": summary.calorie,
+                "duration_s": summary.run_time,
+                "avg_pace": summary.avg_pace,
+                "workout_type": summary.type,
+            }]
+            df = pd.DataFrame(data)
+            columns = [
+                "track_date",
+                "timestamp",
+                "latitude",
+                "longitude",
+                "altitude",
+                "heart_rate",
+                "cadence",
+                "distance_km",
+                "calories",
+                "duration_s",
+                "avg_pace",
+                "workout_type",
+            ]
+            df = df[columns]
 
         ext = output_file_path.suffix
 
-        if ext == ".geojson":
-            gdf.to_file(output_file_path, driver="GeoJSON")
-        elif ext == ".gpkg":
-            gdf.to_file(output_file_path, driver="GPKG")
-        elif ext == ".parquet":
-            gdf.to_parquet(output_file_path)
-        elif ext == ".shp":
-            gdf.to_file(output_file_path, driver="ESRI Shapefile")
-        elif ext == ".csv":
-            gdf.to_csv(output_file_path)
-        elif ext == ".json":
-            gdf.to_json(str(output_file_path))
-        elif ext == ".xslx":
-            gdf.to_excel(output_file_path)
-        elif ext in [".sql", ".sqlite3"]:
-            con = sqlite3.connect(":memory:" if ext == ".sql" else output_file_path)
-            gdf.drop(columns=["geometry"]).to_sql(
-                name="points", con=con, if_exists="append"
-            )
+        if points:
+            if ext == ".geojson":
+                gdf.to_file(output_file_path, driver="GeoJSON")
+            elif ext == ".gpkg":
+                gdf.to_file(output_file_path, driver="GPKG")
+            elif ext == ".parquet":
+                gdf.to_parquet(output_file_path)
+            elif ext == ".shp":
+                gdf.to_file(output_file_path, driver="ESRI Shapefile")
+            elif ext == ".csv":
+                gdf.to_csv(output_file_path)
+            elif ext == ".json":
+                gdf.to_json(str(output_file_path))
+            elif ext == ".xlsx":
+                gdf.to_excel(output_file_path)
+            elif ext in [".sql", ".sqlite3"]:
+                con = sqlite3.connect(
+                    ":memory:" if ext == ".sql" else output_file_path)
+                gdf.drop(columns=["geometry"]).to_sql(
+                    name="points", con=con, if_exists="append"
+                )
 
-            if ext == ".sql":
-                with open(output_file_path, "w") as f:
-                    for line in con.iterdump():
-                        f.write(f"{line}\n")
-        elif ext == ".xml":
-            gdf.to_xml(output_file_path)
-        elif ext == ".html":
-            gdf.to_html(output_file_path)
+                if ext == ".sql":
+                    with open(output_file_path, "w") as f:
+                        for line in con.iterdump():
+                            f.write(f"{line}\n")
+            elif ext == ".xml":
+                gdf.to_xml(output_file_path)
+            elif ext == ".html":
+                gdf.to_html(output_file_path)
+            else:
+                LOGGER.error(f"File format is not implemented: {ext}")
         else:
-            LOGGER.error(f"File format is not implemented: {ext}")
+            # For no GPS data, export metadata
+            if ext == ".csv":
+                df.to_csv(output_file_path, index=False)
+            elif ext == ".json":
+                df.to_json(str(output_file_path), orient="records")
+            elif ext == ".xlsx":
+                df.to_excel(output_file_path, index=False)
+            elif ext in [".sql", ".sqlite3"]:
+                con = sqlite3.connect(
+                    ":memory:" if ext == ".sql" else output_file_path)
+                df.to_sql(name="workouts", con=con,
+                          if_exists="append", index=False)
+
+                if ext == ".sql":
+                    with open(output_file_path, "w") as f:
+                        for line in con.iterdump():
+                            f.write(f"{line}\n")
+            elif ext == ".xml":
+                df.to_xml(output_file_path)
+            elif ext == ".html":
+                df.to_html(output_file_path, index=False)
+            else:
+                # For geo formats without GPS, export as CSV
+                df.to_csv(output_file_path.with_suffix(".csv"), index=False)

--- a/src/exporters/geopandas_exporter.py
+++ b/src/exporters/geopandas_exporter.py
@@ -7,7 +7,7 @@ from typing import List
 import geopandas as gpd
 from shapely.geometry import Point
 
-from src.api import WorkoutSummary
+from src.api import WorkoutDetail, WorkoutSummary
 from src.exporters.base_exporter import BaseExporter, ExportablePoint
 
 LOGGER = logging.getLogger(__name__)
@@ -34,6 +34,7 @@ class GeoPandasExporter(BaseExporter):
         output_file_path: Path,
         summary: WorkoutSummary,
         points: List[ExportablePoint],
+        detail: WorkoutDetail,
     ):
         track_date = datetime.utcfromtimestamp(
             int(summary.trackid)).isoformat()
@@ -50,6 +51,14 @@ class GeoPandasExporter(BaseExporter):
                     "cadence": point.cadence,
                     # Note: Point(lon, lat)
                     "geometry": Point(point.longitude, point.latitude),
+                    "user": detail.activity.get("user") if detail.activity else None,
+                    "device": detail.activity.get("device") if detail.activity else None,
+                    "activity_date": detail.activity.get("date") if detail.activity else None,
+                    "start_time": detail.activity.get("start_time") if detail.activity else None,
+                    "duration": detail.summary.get("duration") if detail.summary else None,
+                    "calories_kcal": detail.summary.get("calories_kcal") if detail.summary else None,
+                    "avg_bpm": detail.summary.get("heart_rate", {}).get("avg_bpm") if detail.summary and detail.summary.get("heart_rate") else None,
+                    "max_bpm": detail.summary.get("heart_rate", {}).get("max_bpm") if detail.summary and detail.summary.get("heart_rate") else None,
                 }
                 for point in points
             ]
@@ -83,6 +92,19 @@ class GeoPandasExporter(BaseExporter):
                 "duration_s": summary.run_time,
                 "avg_pace": summary.avg_pace,
                 "workout_type": summary.type,
+                "total_steps": summary.total_step,
+                "altitude_ascend": summary.altitude_ascend,
+                "altitude_descend": summary.altitude_descend,
+                "max_pace": summary.max_pace,
+                "min_pace": summary.min_pace,
+                "user": detail.activity.get("user") if detail.activity else None,
+                "device": detail.activity.get("device") if detail.activity else None,
+                "activity_date": detail.activity.get("date") if detail.activity else None,
+                "start_time": detail.activity.get("start_time") if detail.activity else None,
+                "duration": detail.summary.get("duration") if detail.summary else None,
+                "calories_kcal": detail.summary.get("calories_kcal") if detail.summary else None,
+                "avg_bpm": detail.summary.get("heart_rate", {}).get("avg_bpm") if detail.summary and detail.summary.get("heart_rate") else None,
+                "max_bpm": detail.summary.get("heart_rate", {}).get("max_bpm") if detail.summary and detail.summary.get("heart_rate") else None,
             }]
             df = pd.DataFrame(data)
             columns = [
@@ -98,6 +120,19 @@ class GeoPandasExporter(BaseExporter):
                 "duration_s",
                 "avg_pace",
                 "workout_type",
+                "total_steps",
+                "altitude_ascend",
+                "altitude_descend",
+                "max_pace",
+                "min_pace",
+                "user",
+                "device",
+                "activity_date",
+                "start_time",
+                "duration",
+                "calories_kcal",
+                "avg_bpm",
+                "max_bpm",
             ]
             df = df[columns]
 

--- a/src/exporters/gpx_exporter.py
+++ b/src/exporters/gpx_exporter.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from src.api import WorkoutSummary
+from src.api import WorkoutDetail, WorkoutSummary
 from src.exporters.base_exporter import BaseExporter, ExportablePoint
 
 LOGGER = logging.getLogger(__name__)
@@ -38,6 +38,7 @@ class GpxExporter(BaseExporter):
         output_file_path: Path,
         summary: WorkoutSummary,
         points: List[ExportablePoint],
+        detail: WorkoutDetail,
     ):
         ind = "\t"
         with output_file_path.open(mode="w") as fp:
@@ -63,6 +64,48 @@ class GpxExporter(BaseExporter):
                 desc_parts.append(f"Avg Pace: {summary.avg_pace}")
             if summary.avg_heart_rate:
                 desc_parts.append(f"Avg HR: {summary.avg_heart_rate}")
+            # Add more metadata
+            if summary.total_step:
+                desc_parts.append(f"Steps: {summary.total_step}")
+            if summary.altitude_ascend:
+                desc_parts.append(f"Ascend: {summary.altitude_ascend} m")
+            if summary.altitude_descend:
+                desc_parts.append(f"Descend: {summary.altitude_descend} m")
+            if summary.max_pace:
+                desc_parts.append(f"Max Pace: {summary.max_pace}")
+            if summary.min_pace:
+                desc_parts.append(f"Min Pace: {summary.min_pace}")
+            # Add additional data from detail
+            if detail.activity:
+                if detail.activity.get("user"):
+                    desc_parts.append(f"User: {detail.activity['user']}")
+                if detail.activity.get("device"):
+                    desc_parts.append(f"Device: {detail.activity['device']}")
+                if detail.activity.get("date"):
+                    desc_parts.append(f"Date: {detail.activity['date']}")
+                if detail.activity.get("start_time"):
+                    desc_parts.append(
+                        f"Start Time: {detail.activity['start_time']}")
+            if detail.summary:
+                if detail.summary.get("duration"):
+                    desc_parts.append(
+                        f"Duration: {detail.summary['duration']}")
+                if detail.summary.get("calories_kcal"):
+                    desc_parts.append(
+                        f"Calories: {detail.summary['calories_kcal']} kcal")
+                if detail.summary.get("heart_rate") and detail.summary["heart_rate"].get("avg_bpm"):
+                    desc_parts.append(
+                        f"Avg BPM: {detail.summary['heart_rate']['avg_bpm']}")
+                if detail.summary.get("heart_rate") and detail.summary["heart_rate"].get("max_bpm"):
+                    desc_parts.append(
+                        f"Max BPM: {detail.summary['heart_rate']['max_bpm']}")
+            if detail.heart_rate_zones:
+                zones = []
+                for zone_name, zone_data in detail.heart_rate_zones.items():
+                    if zone_data.get("time") and zone_data["time"] != "00:00":
+                        zones.append(f"{zone_name}: {zone_data['time']}")
+                if zones:
+                    desc_parts.append(f"HR Zones: {', '.join(zones)}")
             if desc_parts:
                 desc = "; ".join(desc_parts)
                 fp.write(f"{ind}{ind}<desc>{desc}</desc>\n")

--- a/src/exporters/gpx_exporter.py
+++ b/src/exporters/gpx_exporter.py
@@ -23,7 +23,8 @@ WORKOUT_TYPE_MAP = {
 
 def _map_workout_type(summary: WorkoutSummary) -> Optional[str]:
     if not (workout_type := WORKOUT_TYPE_MAP.get(summary.type)):
-        LOGGER.warning(f"Unhandled type for workout {summary.trackid}: {summary.type}")
+        LOGGER.warning(
+            f"Unhandled type for workout {summary.trackid}: {summary.type}")
 
     return workout_type
 
@@ -50,6 +51,21 @@ class GpxExporter(BaseExporter):
             fp.write(f"{ind}<metadata><time>{time}</time></metadata>\n")
             fp.write(f"{ind}<trk>\n")
             fp.write(f"{ind}{ind}<name>{time}</name>\n")
+            # Add description with workout metadata
+            desc_parts = []
+            if summary.dis:
+                desc_parts.append(f"Distance: {summary.dis} km")
+            if summary.calorie:
+                desc_parts.append(f"Calories: {summary.calorie}")
+            if summary.run_time:
+                desc_parts.append(f"Duration: {summary.run_time} s")
+            if summary.avg_pace:
+                desc_parts.append(f"Avg Pace: {summary.avg_pace}")
+            if summary.avg_heart_rate:
+                desc_parts.append(f"Avg HR: {summary.avg_heart_rate}")
+            if desc_parts:
+                desc = "; ".join(desc_parts)
+                fp.write(f"{ind}{ind}<desc>{desc}</desc>\n")
 
             if workout_type := _map_workout_type(summary):
                 fp.write(f"{ind}{ind}<type>{workout_type}</type>\n")

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -55,11 +55,17 @@ class Scraper:
             detail = self.api.get_workout_detail(summary)
 
             points = parse_points(summary, detail.data)
-            if not points and not self.include_no_gps:
-                LOGGER.warning(
-                    f"Skipping workout {summary.trackid} because it has no points"
-                )
-                continue
+            if not points:
+                if not self.include_no_gps:
+                    LOGGER.warning(
+                        f"Skipping workout {summary.trackid} because it has no points"
+                    )
+                    continue
+                else:
+                    LOGGER.info(
+                        f"Detail for workout {summary.trackid} (no GPS): activity={detail.activity}, summary={detail.summary}, heart_rate_zones={detail.heart_rate_zones}")
+
+            track_id = int(summary.trackid)
 
             track_id = int(summary.trackid)
             file_name = datetime.fromtimestamp(track_id).strftime(
@@ -70,5 +76,5 @@ class Scraper:
             output_file_path.parent.mkdir(exist_ok=True)
             assert output_file_path.parent.exists(), "Couldn't create output folder"
 
-            self.exporter.export(output_file_path, summary, points)
+            self.exporter.export(output_file_path, summary, points, detail)
             LOGGER.info(f"Downloaded {output_file_path}")

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Scraper:
     def __init__(
-        self, api: Api, exporter: BaseExporter, output_dir: Path, file_format: str, start_ts: float, end_ts: float
+        self, api: Api, exporter: BaseExporter, output_dir: Path, file_format: str, start_ts: float, end_ts: float, include_no_gps: bool = False
     ):
         self.api: Api = api
         self.exporter: BaseExporter = exporter
@@ -19,6 +19,7 @@ class Scraper:
         self.file_format: str = file_format
         self.start_ts: float = start_ts
         self.end_ts: float = end_ts
+        self.include_no_gps: bool = include_no_gps
 
         if start_ts > end_ts:
             raise ValueError("Start date cannot be after end date")
@@ -36,7 +37,8 @@ class Scraper:
             logging.info(
                 f"Fetching more summaries starting from workout {history.data.next}"
             )
-            history = self.api.get_workout_history(from_track_id=history.data.next)
+            history = self.api.get_workout_history(
+                from_track_id=history.data.next)
             summaries.extend(history.data.summary)
 
         logging.info(f"There are {len(summaries)} workouts in total")
@@ -52,7 +54,8 @@ class Scraper:
         for summary in filtered_summaries:
             detail = self.api.get_workout_detail(summary)
 
-            if not (points := parse_points(summary, detail.data)):
+            points = parse_points(summary, detail.data)
+            if not points and not self.include_no_gps:
                 LOGGER.warning(
                     f"Skipping workout {summary.trackid} because it has no points"
                 )


### PR DESCRIPTION
## Summary

This PR adds support for exporting workouts that do not contain GPS data and improves metadata extraction from the API.

Previously, workouts without GPS points were skipped entirely during export. With this change, users can optionally include these workouts using the new CLI flag:

`--include-no-gps`

In addition, exported files now contain richer metadata extracted from API responses.

## Key Changes

### CLI

#### `main.py`

Added a new command-line flag:

`--include-no-gps`

When enabled, workouts without GPS data are included in the export.

Default behavior remains unchanged — such workouts are still skipped unless the flag is used.

### Scraper Improvements

#### `scraper.py`

Changes include:

- Added `include_no_gps` parameter to `Scraper.__init__`
- Updated export logic:
  - workouts without GPS points are skipped **only if** `--include-no-gps` is not provided
- Added detailed logging for workouts without GPS data, including:
  - `activity`
  - `summary`
  - `heart_rate_zones`

This helps debugging API responses.

### API Model Extensions

#### `api.py`

The `WorkoutDetail` model has been extended with optional fields:

- `activity`
- `summary`
- `heart_rate_zones`

These fields allow additional workout metadata from API responses to be captured and reused by exporters.

### Exporter Updates

#### Base Exporter (`base_exporter.py`)

Updates:

- Added import of `WorkoutDetail`
- Updated exporter interface to accept `detail: WorkoutDetail`

This allows exporters to use detailed workout metadata.

#### GPX Exporter Enhancements

#### `gpx_exporter.py`

Updates include:

- Added `WorkoutDetail` import
- Updated `export()` signature to accept `detail`
- Enhanced the `<desc>` tag with additional metadata

New fields included:

- steps
- altitude ascend / descend
- max pace
- min pace
- activity metadata
- summary information
- heart rate zones (if available)

#### GeoPandas Exporter Enhancements

#### `geopandas_exporter.py`

Updates include:

- Added `WorkoutDetail` import
- Updated `export()` method to accept `detail`
- Added new metadata columns:

- `total_steps`
- `altitude_ascend`
- `altitude_descend`
- `max_pace`
- `min_pace`
- `user`
- `device`
- `activity_date`
- `start_time`
- `duration`
- `calories_kcal`
- `avg_bpm`
- `max_bpm`

For workouts without GPS data, the exporter now outputs tabular data (CSV/JSON/etc.) containing all available metadata.

## Usage

To export **all workouts including those without GPS data**:

```bash
python main.py --include-no-gps